### PR TITLE
feat(CssModule::Transformer): yield (name, path) per input to class_names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/proscenium/css_module/transformer.rb
+++ b/lib/proscenium/css_module/transformer.rb
@@ -33,31 +33,22 @@ module Proscenium
     #   class_names "mypackage/button@large"
     #   class_names "@scoped/package/button@small"
     #
+    # When a block is given, it is yielded once per input name with
+    # `(transformed_name, side_load_path)`. `side_load_path` is the exact string passed to
+    # `Importer.import` for that name, or `nil` for names that did not trigger a side-load (plain
+    # class names with `require_prefix: true`). The return value is unchanged — callers that don't
+    # need the path can keep ignoring the block.
+    #
     # @param names [String,Symbol,Array<String,Symbol>]
     # @param require_prefix: [Boolean] whether or not to require the `@` prefix.
+    # @yieldparam transformed_name [String]
+    # @yieldparam side_load_path [String, nil]
     # @return [Array<String>] the transformed CSS module names.
     def class_names(*names, require_prefix: true)
       names.map do |name|
-        original_name = name.dup
-        name = name.to_s if name.is_a?(Symbol)
-
-        if name.include?('/')
-          if name.start_with?('@')
-            # Scoped bare specifier (eg. "@scoped/package/lib/button@default").
-            _, path, name = name.split('@')
-            path = "@#{path}"
-          else
-            # Local path (eg. /some/path/to/button@default") or bare specifier (eg.
-            # "mypackage/lib/button@default").
-            path, name = name.split('@')
-          end
-
-          class_name! name, original_name, path: "#{path}#{FILE_EXT}"
-        elsif name.start_with?('@')
-          class_name! name[1..], original_name
-        else
-          require_prefix ? name : class_name!(name, original_name)
-        end
+        transformed, path = transform_class_name(name, require_prefix: require_prefix)
+        yield(transformed, path) if block_given?
+        transformed
       end
     end
 
@@ -73,6 +64,39 @@ module Proscenium
         "_#{transformed_name[1..]}_#{digest}"
       else
         "#{transformed_name}_#{digest}"
+      end
+    end
+
+    private
+
+    # Returns `[transformed_name, side_load_path]` for a single class-name reference.
+    # `side_load_path` is the exact string that `class_name!` passed to `Importer.import`, or
+    # `nil` if the name did not trigger a side-load. Extracted so `#class_names` can yield paths
+    # to consumers (e.g. proscenium-phlex's `resolved_css_module_paths` replay registry) without
+    # re-parsing names.
+    def transform_class_name(name, require_prefix:)
+      original_name = name.dup
+      name = name.to_s if name.is_a?(Symbol)
+
+      if name.include?('/')
+        if name.start_with?('@')
+          # Scoped bare specifier (eg. "@scoped/package/lib/button@default").
+          _, path, name = name.split('@')
+          path = "@#{path}"
+        else
+          # Local path (eg. /some/path/to/button@default") or bare specifier (eg.
+          # "mypackage/lib/button@default").
+          path, name = name.split('@')
+        end
+
+        module_path = "#{path}#{FILE_EXT}"
+        [class_name!(name, original_name, path: module_path), module_path]
+      elsif name.start_with?('@')
+        [class_name!(name[1..], original_name), @source_path&.to_s]
+      elsif require_prefix
+        [name, nil]
+      else
+        [class_name!(name, original_name), @source_path&.to_s]
       end
     end
   end

--- a/test/css_module/transformer_test.rb
+++ b/test/css_module/transformer_test.rb
@@ -123,4 +123,70 @@ class Proscenium::CssModule::TransformerTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe '#class_names with block' do
+    let(:transformer) do
+      Proscenium::CssModule::Transformer.new('/lib/css_modules/basic')
+    end
+
+    it 'yields (transformed_name, side_load_path) for a `@name` reference' do
+      yielded = []
+      result = transformer.class_names(:@title) { |name, path| yielded << [name, path] }
+
+      assert_equal 1, yielded.length
+      assert_match(/^title_[a-z0-9]{8}_lib-css_modules-basic-module$/, yielded.first.first)
+      assert_equal '/lib/css_modules/basic.module.css', yielded.first.last
+      assert_equal result, [yielded.first.first]
+    end
+
+    it 'yields for a `/path@name` reference with the explicit module path' do
+      yielded = []
+      transformer.class_names('/lib/css_modules/basic2@title') do |name, path|
+        yielded << [name, path]
+      end
+
+      assert_match(/^title_[a-z0-9]{8}_lib-css_modules-basic2-module$/, yielded.first.first)
+      assert_equal '/lib/css_modules/basic2.module.css', yielded.first.last
+    end
+
+    it 'yields a nil side_load_path for plain class names with require_prefix: true' do
+      yielded = []
+      transformer.class_names(:title) { |_name, path| yielded << path }
+
+      assert_equal [nil], yielded
+    end
+
+    it 'yields the source path for plain class names with require_prefix: false' do
+      yielded = []
+      transformer.class_names(:title, require_prefix: false) do |name, path|
+        yielded << [name, path]
+      end
+
+      assert_equal 1, yielded.length
+      assert_match(/^title_[a-z0-9]{8}_lib-css_modules-basic-module$/, yielded.first.first)
+      assert_equal '/lib/css_modules/basic.module.css', yielded.first.last
+    end
+
+    it 'yields the same path string that Importer.import received' do
+      Proscenium::Importer.reset
+
+      transformer.class_names('/lib/css_modules/basic2@title') do |_name, path|
+        assert_includes Proscenium::Importer.imported.keys, path
+      end
+    end
+
+    it 'yields for every input name and preserves order' do
+      yielded = []
+      transformer.class_names(:@title, :plain, '/lib/css_modules/basic2@subtitle') do |name, path|
+        yielded << [name, path]
+      end
+
+      assert_equal 3, yielded.length
+      assert_match(/^title_[a-z0-9]{8}_/, yielded[0].first)
+      assert_equal '/lib/css_modules/basic.module.css', yielded[0].last
+      assert_equal ['plain', nil], yielded[1]
+      assert_match(/^subtitle_[a-z0-9]{8}_/, yielded[2].first)
+      assert_equal '/lib/css_modules/basic2.module.css', yielded[2].last
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds a non-breaking block form to `Proscenium::CssModule::Transformer#class_names`. When a block is given, it is yielded once per input name with `(transformed_name, side_load_path)`. `side_load_path` is the **exact string** passed to `Importer.import` for that name, or `nil` for plain names that don't trigger a side-load.

The return value is unchanged — still an `Array<String>` — so every existing caller (`Proscenium::CssModule::ClassMethods#css_module`, `#class_names`, the instance forms, and `Proscenium::Helper.css_module`) continues to work without modification.

## Why

Today the only way to learn which CSS module file a class name resolves to is to either:

1. Re-parse the name string yourself (mirroring the path-extraction in `class_names` — brittle, drifts on every new specifier form), or
2. Wrap/instrument `Importer.import` to capture what `class_name!` calls it with (heavy, fragile across versions).

Both are dead ends. The transformer already knows the path — it just discards it after handing it to `Importer.import`.

A concrete consumer this unblocks: `proscenium-phlex 0.6.0`'s `Proscenium::Phlex::CssModules#process_attributes` ([css_modules.rb#L70-L83](https://github.com/joelmoss/proscenium-phlex/blob/master/lib/proscenium/phlex/css_modules.rb#L70-L83)) maintains a class-level `resolved_css_module_paths` registry so `after_template` can replay side-loading when Phlex's process-wide `ATTRIBUTE_CACHE` short-circuits `process_attributes` on subsequent renders of the same `(attributes, class)` pair. The current population code:

```ruby
attributes[:class] = cssm.class_names(*names).map do |name, path|
  self.class.resolved_css_module_paths << path if path
  name
end
```

assumes `class_names` returns `[name, path]` tuples — it doesn't, so `path` is always `nil` and the registry stays permanently empty. The block API surfaces the path that `class_name!` already computed, so `proscenium-phlex` can do:

```ruby
attributes[:class] = cssm.class_names(*names) do |_name, path|
  resolved_css_module_paths << path if path
end
```

without re-parsing class names. The companion fix in proscenium-phlex is at joelmoss/proscenium-phlex#1.

## Implementation

- The per-name branch logic is extracted into a small private `#transform_class_name` helper that returns `[transformed_name, side_load_path]`. The path for each branch is the **exact** string `class_name!` passes to `Importer.import` (covering `@name`, `/path@name`, `@scope/path@name`, and `require_prefix: false` bare names), or `nil` for plain names that don't trigger a side-load.
- `#class_names` becomes a tiny `names.map` that calls the helper, yields if a block is given, and returns the transformed name. No behaviour change without a block.

## Test plan

- [x] All 105 pre-existing tests pass unchanged.
- [x] 6 new tests in `test/css_module/transformer_test.rb` cover the new yield contract:
  - `:@name` reference yields the source path
  - `/path@name` reference yields the explicit module path
  - plain class name with `require_prefix: true` yields `nil` path
  - plain class name with `require_prefix: false` yields the source path
  - yielded path matches `Importer.imported.keys` exactly (proves no key drift)
  - yield fires once per input, preserving order
- [x] Rubocop clean.